### PR TITLE
Remove unused variables and improve error messages

### DIFF
--- a/weblorean.py
+++ b/weblorean.py
@@ -93,8 +93,8 @@ class WebLorean():
                                           port,
                                           socket.AF_INET,
                                           socket.SOCK_STREAM)
-        except:
-            pass
+        except Exception as err:
+            print("socket.getaddrinfo failed: {}".format(err))
         else:
             for x in infolist:
                 iplist.append(x[4][0])
@@ -193,12 +193,9 @@ class WebLorean():
                 t = list(set(addrs))
                 self.ipv4_history.extend(t)
                 print("{}: Found {} IP addresses".format(method, len(t)))
-            pass
         else:
             self.ipv4_history = getattr(self,WebLorean.METHODS[self.method])()
-        total = len(self.ipv4_history)
         self.ipv4_history = list(set(self.ipv4_history))
-        uniq_total = len(self.ipv4_history)
         return(self.ipv4_history)
 
     def hhMethod_dnshistory(self):
@@ -235,7 +232,7 @@ class WebLorean():
         DATAURL = '{}={}'.format(BASE, self.url)
         try:
             print("SELENIUM: Accessing {}".format(DATAURL))
-            ret = browser.get(DATAURL)
+            browser.get(DATAURL)
         except:
             print("SELENIUM: Exception. Exiting. Check {}".format(logpath))
             browser.quit()
@@ -268,7 +265,7 @@ class WebLorean():
         DATAURL = '{}={}'.format(BASE, self.fqdn)
         try:
             print("SELENIUM: Accessing {}".format(DATAURL))
-            ret = browser.get(DATAURL)
+            browser.get(DATAURL)
         except:
             print("SELENIUM: Exception. Exiting. Check {}".format(logpath))
             browser.quit()


### PR DESCRIPTION
## Summary
- remove unused variables from `get_hosting_history`
- log failures in `get_ipv4_records`
- drop unused `ret` variables

## Testing
- `flake8 | grep F841 -n`

------
https://chatgpt.com/codex/tasks/task_e_6872bd7fda04832fa13fbc4fda300c17