### PR TITLE
Add chromedriver path CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,12 @@ Make sure you __source fix_environment.sh__ if you are running Ubuntu!
 ```
 cd weblorean
 ./weblorean.py http://www.example.org
+
+# specify a custom chromedriver path
+./weblorean.py --chromedriver-path /usr/lib/chromium-browser/chromedriver http://www.example.org
 ```
+
+By default WebLorean looks for a `chromedriver` executable in the current directory.
 
 ## What about Windows Subsystem for Linux?
 

--- a/weblorean.py
+++ b/weblorean.py
@@ -5,6 +5,7 @@ import sys
 import time
 import socket
 import argparse
+import os
 import requests
 import urllib3
 from pprint import pprint
@@ -62,7 +63,7 @@ class WebLorean():
                'dnstrails': 'hhMethod_dnstrails',
                'all': 'hhMethod_all',}
 
-    def __init__(self, target=None, method=None):
+    def __init__(self, target=None, method=None, chromedriver_path=None):
         # Target http validation implemented on ArgParser via type=
         if target is None:
             return(None)
@@ -74,6 +75,10 @@ class WebLorean():
         self.url = target
         self.fqdn = target.replace('http://', '').replace('https://', '')
         self.proto = self.url.split("://")[0]
+
+        if chromedriver_path is None:
+            chromedriver_path = os.path.join(os.getcwd(), 'chromedriver')
+        self.chromedriver_path = chromedriver_path
 
         # ipv4_current holds all IPv4 addresses currently in DNS for fqdn
         self.ipv4_current = None  # updated by self.get_ipv4_records()
@@ -226,7 +231,7 @@ class WebLorean():
         display.start()
         time.sleep(3)  # TODO: puaj
         service_args = ['--verbose']
-        browser = webdriver.Chrome('/usr/lib/chromium-browser/chromedriver',
+        browser = webdriver.Chrome(self.chromedriver_path,
                                    service_args=service_args,
                                    service_log_path=logpath)
         time.sleep(3)  # TODO: puaj
@@ -260,7 +265,7 @@ class WebLorean():
         display.start()
         time.sleep(3)  # TODO: puaj
         service_args = ['--verbose']
-        browser = webdriver.Chrome('/usr/lib/chromium-browser/chromedriver',
+        browser = webdriver.Chrome(self.chromedriver_path,
                                    service_args=service_args,
                                    service_log_path=logpath)
         time.sleep(3)  # TODO: puaj
@@ -336,6 +341,9 @@ if __name__ == '__main__':
                         default='all',
                         help=help,
                         choices=WebLorean.METHODS.keys())
+    parser.add_argument("--chromedriver-path",
+                        default=os.path.join(os.getcwd(), 'chromedriver'),
+                        help="Path to chromedriver binary (default: ./chromedriver)")
     parser.add_argument("--version",
                         help="Show version",
                         action='version',
@@ -353,7 +361,8 @@ if __name__ == '__main__':
         print("Using '{}' method.".format(args.method))
         try:
             wl = WebLorean(target=target,
-                           method=args.method)
+                           method=args.method,
+                           chromedriver_path=args.chromedriver_path)
         except ValueError as err:
             print("Err >> WebLorean: Exception: {}".format(target, err))
             continue


### PR DESCRIPTION
## Summary
- allow user to pass the path to chromedriver via `--chromedriver-path`
- use the option in the Selenium helpers
- document the option in README

## Testing
- `python3 -m py_compile weblorean.py`
- `python3 weblorean.py --help` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6872bd882e94832f84cf212e3ef4a35f