### PR TITLE
Add pytest suite and fix import issues

### DIFF
--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import pytest
+import argparse
+import requests
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from weblorean import WLArgParseHelpers
+
+class DummyResponse:
+    def __init__(self, status_code):
+        self.status_code = status_code
+
+
+def test_try_url_success(monkeypatch):
+    def fake_get(url, timeout=None, verify=None):
+        return DummyResponse(200)
+    monkeypatch.setattr('requests.get', fake_get)
+    assert WLArgParseHelpers.try_url('http://example.com') == 'http://example.com'
+
+
+def test_try_url_non_200(monkeypatch):
+    def fake_get(url, timeout=None, verify=None):
+        return DummyResponse(404)
+    monkeypatch.setattr('requests.get', fake_get)
+    with pytest.raises(argparse.ArgumentTypeError):
+        WLArgParseHelpers.try_url('http://example.com')
+
+
+def test_try_url_timeout(monkeypatch):
+    def fake_get(url, timeout=None, verify=None):
+        raise requests.Timeout
+    monkeypatch.setattr('requests.get', fake_get)
+    with pytest.raises(argparse.ArgumentTypeError):
+        WLArgParseHelpers.try_url('http://example.com')

--- a/tests/test_scrapers.py
+++ b/tests/test_scrapers.py
@@ -1,0 +1,57 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from weblorean import WebLorean
+
+
+def test_viewdns_scrape():
+    html = """
+    <html><body><table>
+        <tr><td>1.2.3.4</td><td>date</td></tr>
+        <tr><td>5.6.7.8</td></tr>
+    </table></body></html>
+    """
+    wl = WebLorean(target="http://example.com")
+    ips = wl.viewdns_scrape(html)
+    assert set(ips) == {"1.2.3.4", "5.6.7.8"}
+
+
+def test_dnshistory_scrape():
+    html = """
+    <html><body>
+        <a href='/dns-records/1.2.3.4.in-addr.arpa.html'>x</a>
+        <a href='/dns-records/5.6.7.8.in-addr.arpa.html'>x</a>
+    </body></html>
+    """
+    wl = WebLorean(target="http://example.com")
+    ips = wl.dnshistory_scrape(html)
+    assert set(ips) == {"1.2.3.4", "5.6.7.8"}
+
+
+def test_dnstrails_scrape():
+    html = """
+    <html><body>
+        <a href='/tools/lookup.htm?ip=8.8.8.8&date=2017-01-01'>x</a>
+        <a href='/tools/lookup.htm?ip=9.9.9.9&date=2017-01-02'>x</a>
+    </body></html>
+    """
+    wl = WebLorean(target="http://example.com")
+    ips = wl.dnstrails_scrape(html)
+    assert set(ips) == {"8.8.8.8", "9.9.9.9"}
+
+
+def test_netcraft_scrape():
+    html = """
+    <html><body>
+      <section class='site_report_table' id='history_table'>
+        <tr><td>A</td><td>1.1.1.1</td></tr>
+        <tr><td>A</td><td>2.2.2.2</td></tr>
+      </section>
+    </body></html>
+    """
+    wl = WebLorean(target="http://example.com")
+    ips = wl.netcraft_scrape(html)
+    assert set(ips) == {"1.1.1.1", "2.2.2.2"}

--- a/weblorean.py
+++ b/weblorean.py
@@ -242,13 +242,13 @@ class WebLorean():
         try:
             print("SELENIUM: Accessing {}".format(DATAURL))
             browser.get(DATAURL)
-        except:
-            ret = browser.get(DATAURL)
         except WebDriverException:
 
             print("SELENIUM: Exception. Exiting. Check {}".format(logpath))
             browser.quit()
             display.stop()
+        except Exception:
+            browser.get(DATAURL)
         try:
             HTML = browser.page_source
         except WebDriverException:
@@ -282,8 +282,8 @@ class WebLorean():
             print("SELENIUM: Exception. Exiting. Check {}".format(logpath))
             browser.quit()
             display.stop()
-        except:
-            ret = browser.get(DATAURL)
+        except Exception:
+            browser.get(DATAURL)
         try:
             HTML = browser.page_source
         except WebDriverException:


### PR DESCRIPTION
## Summary
- fix Python 3.12 except ordering to avoid syntax error
- add tests for scraping helpers
- add tests for argument validator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872caba7e04832fa3d01f473ade6e40